### PR TITLE
Add option to enable PPP Multilink

### DIFF
--- a/properties/nm-l2tp-dialog.ui
+++ b/properties/nm-l2tp-dialog.ui
@@ -1770,7 +1770,7 @@ config: noaccomp (when unchecked)</property>
                   <object class="GtkLabel" id="label11">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Echo</property>
+                    <property name="label" translatable="yes">Misc</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -1788,15 +1788,117 @@ config: noaccomp (when unchecked)</property>
                     <property name="can_focus">False</property>
                     <property name="left_padding">12</property>
                     <child>
-                      <object class="GtkCheckButton" id="ppp_send_echo_packets">
-                        <property name="label" translatable="yes">Send PPP _echo packets</property>
+                      <object class="GtkBox">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">Send LCP echo-requests to find out whether peer is alive.
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkCheckButton" id="ppp_send_echo_packets">
+                            <property name="label" translatable="yes">Send PPP _echo packets</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="tooltip_text" translatable="yes">Send LCP echo-requests to find out whether peer is alive.
 config: lcp-echo-failure and lcp-echo-interval</property>
-                        <property name="use_underline">True</property>
-                        <property name="draw_indicator">True</property>
+                            <property name="halign">start</property>
+                            <property name="use_underline">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="label13">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">MTU:</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="ppp_mtu_spinbutton">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="max_length">4</property>
+                                <property name="width_chars">4</property>
+                                <property name="max_width_chars">4</property>
+                                <property name="text" translatable="yes">1400</property>
+                                <property name="adjustment">ppp_mtu_adjustment</property>
+                                <property name="climb_rate">1</property>
+                                <property name="value">1400</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox6">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="label16">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">MRU:</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="ppp_mru_spinbutton">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="max_length">4</property>
+                                <property name="width_chars">4</property>
+                                <property name="max_width_chars">4</property>
+                                <property name="text" translatable="yes">1400</property>
+                                <property name="adjustment">ppp_mru_adjustment</property>
+                                <property name="climb_rate">1</property>
+                                <property name="value">1400</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -1814,117 +1916,7 @@ config: lcp-echo-failure and lcp-echo-interval</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="vbox13">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">1</property>
-                <child>
-                  <object class="GtkLabel" id="label12">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Misc</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="hbox5">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="label13">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">MTU :</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSpinButton" id="ppp_mtu_spinbutton">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="max_length">4</property>
-                        <property name="width_chars">4</property>
-                        <property name="max_width_chars">4</property>
-                        <property name="adjustment">ppp_mtu_adjustment</property>
-                        <property name="climb_rate">1</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="hbox6">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="label16">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">MRU :</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSpinButton" id="ppp_mru_spinbutton">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="max_length">4</property>
-                        <property name="width_chars">4</property>
-                        <property name="max_width_chars">4</property>
-                        <property name="adjustment">ppp_mru_adjustment</property>
-                        <property name="climb_rate">1</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
+              <placeholder/>
             </child>
           </object>
           <packing>

--- a/properties/nm-l2tp-dialog.ui
+++ b/properties/nm-l2tp-dialog.ui
@@ -1337,6 +1337,13 @@ config: ipsec-pfs &lt;no/yes&gt;</property>
       </row>
     </data>
   </object>
+  <object class="GtkAdjustment" id="ppp_mrru_adjustment">
+    <property name="lower">1500</property>
+    <property name="upper">4500</property>
+    <property name="value">1600</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="ppp_mru_adjustment">
     <property name="lower">576</property>
     <property name="upper">1500</property>
@@ -1812,6 +1819,91 @@ config: lcp-echo-failure and lcp-echo-interval</property>
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkCheckButton" id="ppp_usemultilink">
+                                <property name="label" translatable="yes">Allow PPP _Multilink</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Try to negotiate a PPP Multilink on a single connection.
+config: multilink and mrru, nomultilink (when unchecked)</property>
+                                <property name="halign">start</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="left_padding">12</property>
+                                <child>
+                                  <object class="GtkBox" id="hbox7">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="ppp_mrru_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">MRRU:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="ppp_mrru_spinbutton">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="max_length">4</property>
+                                        <property name="width_chars">4</property>
+                                        <property name="max_width_chars">4</property>
+                                        <property name="text" translatable="yes">1400</property>
+                                        <property name="adjustment">ppp_mrru_adjustment</property>
+                                        <property name="climb_rate">1</property>
+                                        <property name="value">1600</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkBox" id="hbox5">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -1852,7 +1944,7 @@ config: lcp-echo-failure and lcp-echo-interval</property>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">1</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child>
@@ -1896,7 +1988,7 @@ config: lcp-echo-failure and lcp-echo-interval</property>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>

--- a/shared/nm-service-defines.h
+++ b/shared/nm-service-defines.h
@@ -44,6 +44,8 @@
 #define NM_L2TP_KEY_NO_VJ_COMP        "no-vj-comp"
 #define NM_L2TP_KEY_NO_PCOMP          "nopcomp"
 #define NM_L2TP_KEY_NO_ACCOMP         "noaccomp"
+#define NM_L2TP_KEY_MULTILINK         "multilink"
+#define NM_L2TP_KEY_MRRU              "mrru"
 #define NM_L2TP_KEY_LCP_ECHO_FAILURE  "lcp-echo-failure"
 #define NM_L2TP_KEY_LCP_ECHO_INTERVAL "lcp-echo-interval"
 #define NM_L2TP_KEY_UNIT_NUM          "unit"

--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -156,6 +156,8 @@ static const ValidProperty valid_properties[] = {
 	{ NM_L2TP_KEY_USER_KEY,                 G_TYPE_STRING, FALSE },
 	{ NM_L2TP_KEY_MTU,                      G_TYPE_UINT, FALSE },
 	{ NM_L2TP_KEY_MRU,                      G_TYPE_UINT, FALSE },
+	{ NM_L2TP_KEY_MRRU,                     G_TYPE_UINT, FALSE },
+	{ NM_L2TP_KEY_MULTILINK,                G_TYPE_BOOLEAN, FALSE },
 	{ NM_L2TP_KEY_REFUSE_EAP,               G_TYPE_BOOLEAN, FALSE },
 	{ NM_L2TP_KEY_REFUSE_PAP,               G_TYPE_BOOLEAN, FALSE },
 	{ NM_L2TP_KEY_REFUSE_CHAP,              G_TYPE_BOOLEAN, FALSE },
@@ -1105,6 +1107,19 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 
 	/* Don't need to auth the L2TP server */
 	write_config_option (fd, "noauth\n");
+
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MULTILINK);
+	if (value) {
+		write_config_option (fd, "multilink\n");
+		value = nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_MRRU);
+		if (value) {
+			write_config_option (fd, "mrru %s\n", value);
+		} else {
+			write_config_option (fd, "mrru 1600\n");
+		}
+	} else {
+		write_config_option (fd, "nomultilink\n");
+	}
 
 	/* pppd and xl2tpd on Linux require this option to support Android and iOS clients,
 	   and pppd on Linux clients won't work without the same option */


### PR DESCRIPTION
Useful when dealing with big UDP packets. Supported by Windows and Mikrotik. And pppd.

Short explanation of the option can be found [here](https://wiki.mikrotik.com/wiki/Manual:MLPPP_over_single_and_multiple_links#MLPPP_over_single_link).

I combined Echo and Misc sections before adding checkbox for PPP multilink and spinbutton for MRRU.