### PR TITLE
Honor $CHARONDEBUG and $PLUTODEBUG even without --debug

### DIFF
--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -864,21 +864,19 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 		}
 
 		/* IPsec config section */
-		if (_LOGD_enabled ()){
-			write_config_option (fd, "config setup\n");
-			if (priv->ipsec_daemon == NM_L2TP_IPSEC_DAEMON_LIBRESWAN) {
-				if (getenv ("PLUTODEBUG")) {
-					write_config_option (fd, "  plutodebug=\"%s\"\n\n", getenv ("PLUTODEBUG"));
-				} else {
-					write_config_option (fd, "  plutodebug=\"all\"\n\n");
-				}
-			} else if (priv->ipsec_daemon == NM_L2TP_IPSEC_DAEMON_STRONGSWAN) {
-				if (getenv ("CHARONDEBUG")) {
-					write_config_option (fd, "  charondebug=\"%s\"\n\n", getenv ("CHARONDEBUG"));
-				} else {
-					/* Default strongswan debug level is 1 (control), set it to 2 (controlmore) for ike, esp & cfg */
-					write_config_option (fd, "  charondebug=\"ike 2, esp 2, cfg 2\"\n\n");
-				}
+		write_config_option (fd, "config setup\n");
+		if (priv->ipsec_daemon == NM_L2TP_IPSEC_DAEMON_LIBRESWAN) {
+			if (getenv ("PLUTODEBUG")) {
+				write_config_option (fd, "  plutodebug=\"%s\"\n\n", getenv ("PLUTODEBUG"));
+			} else if (_LOGD_enabled ()){
+				write_config_option (fd, "  plutodebug=\"all\"\n\n");
+			}
+		} else if (priv->ipsec_daemon == NM_L2TP_IPSEC_DAEMON_STRONGSWAN) {
+			if (getenv ("CHARONDEBUG")) {
+				write_config_option (fd, "  charondebug=\"%s\"\n\n", getenv ("CHARONDEBUG"));
+			} else if (_LOGD_enabled ()){
+				/* Default strongswan debug level is 1 (control), set it to 2 (controlmore) for ike, esp & cfg */
+				write_config_option (fd, "  charondebug=\"ike 2, esp 2, cfg 2\"\n\n");
 			}
 		}
 


### PR DESCRIPTION
Useful to reduce debug levels to lower than the default of charon or
pluto.

In my case, I use strongSwan to connect to my company L2TP VPN. I have the following messages in systemd journal every 10 seconds:
```
charon[10192]: 11[NET] received packet: from aaa.bbb.ccc.ddd[4500] to 192.168.xxx.yyy[4500] (108 bytes)
charon[10192]: 11[ENC] parsed INFORMATIONAL_V1 request 356617338 [ HASH N(DPD) ]
charon[10192]: 11[ENC] generating INFORMATIONAL_V1 request 3507737454 [ HASH N(DPD_ACK) ]
charon[10192]: 11[NET] sending packet: from 192.168.xxx.yyy[4500] to aaa.bbb.ccc.ddd[4500] (108 bytes)
```
Here aaa.bbb.ccc.ddd is the IP of the VPN server, and 192.168.xxx.yyy is the internal IP I got for the VPN. Those messages make debugging other issues with systemd journal difficult as the latter is flooded. To get rid of those messages, I can use `$CHARONDEBUG` like this:
```
$ cat /etc/systemd/system/NetworkManager.service.d/silent-l2tp.conf 
[Service]
# Avoiding the following system logs every 10 seconds
Environment=CHARONDEBUG='enc 0, net 0'
```

Here is cleaner diff generated by `git diff --ignore-space-change main..improve-logging`, which may help reviewing:
```Diff
diff --git a/src/nm-l2tp-service.c b/src/nm-l2tp-service.c
index b556e9a..b6689df 100644
--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -864,23 +864,21 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
        }
 
        /* IPsec config section */
-       if (_LOGD_enabled ()){
        write_config_option (fd, "config setup\n");
        if (priv->ipsec_daemon == NM_L2TP_IPSEC_DAEMON_LIBRESWAN) {
            if (getenv ("PLUTODEBUG")) {
                write_config_option (fd, "  plutodebug=\"%s\"\n\n", getenv ("PLUTODEBUG"));
-               } else {
+           } else if (_LOGD_enabled ()){
                write_config_option (fd, "  plutodebug=\"all\"\n\n");
            }
        } else if (priv->ipsec_daemon == NM_L2TP_IPSEC_DAEMON_STRONGSWAN) {
            if (getenv ("CHARONDEBUG")) {
                write_config_option (fd, "  charondebug=\"%s\"\n\n", getenv ("CHARONDEBUG"));
-               } else {
+           } else if (_LOGD_enabled ()){
                /* Default strongswan debug level is 1 (control), set it to 2 (controlmore) for ike, esp & cfg */
                write_config_option (fd, "  charondebug=\"ike 2, esp 2, cfg 2\"\n\n");
            }
        }
-       }
 
        /* strongSwan CA section */
        if (priv->ipsec_daemon == NM_L2TP_IPSEC_DAEMON_STRONGSWAN && priv->machine_authtype == TLS_AUTH) {
```