### PR TITLE
Remove backslash to avoid "invalid sequence" error

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -217,7 +217,7 @@ msgid ""
 "DOMAIN\\username, where DOMAIN is the value from this text entry box."
 msgstr ""
 "Для аутентификации пользователя используйте формат нижнего уровня "
-"на вход, то есть ДОМЕН\имя_пользователя, где ДОМЕН — значение из "
+"на вход, то есть ДОМЕНимя_пользователя, где ДОМЕН — значение из "
 "этого текстового поля."
 
 #: properties/nm-l2tp-dialog.ui:159 properties/nm-l2tp-dialog.ui:376


### PR DESCRIPTION
I encountered an "invalid sequence error" in the `po/ru.po` file, and noticed that a backslash is used against a cyrillic alphabet. 

I am on Kubuntu 20.04 and on a Japanese locale (as seen in the error messages from msgfmt), if this could be a environment-specific issue.

As I do not speak Russian, I do not know if the `\и` was intended to be a typo of `\n` (and thus should be converted into a whitespace) or a typo of adding a extra backslash. It looks like `ДОМЕН` is equivalent to `DOMAIN` so maybe it should be a whitespace character, but as I'm not completely sure, I fixed it by removing the backslash. I would be happy if any Russian speakers can correct me on this.

----

Here's what I did to reproduce the error:

```
$ git clone git@github.com:sylph01/NetworkManager-l2tp.git nml2tp_
Cloning into 'nml2tp_'...
Enter passphrase for key '/home/sylph01/.ssh/id_rsa': 
remote: Enumerating objects: 6677, done.
remote: Counting objects: 100% (895/895), done.
remote: Compressing objects: 100% (466/466), done.
remote: Total 6677 (delta 731), reused 550 (delta 422), pack-reused 5782
Receiving objects: 100% (6677/6677), 5.04 MiB | 947.00 KiB/s, done.
Resolving deltas: 100% (5553/5553), done.

$ cd nml2tp_/
$ ls
AUTHORS  COPYING  ChangeLog  Makefile.am  NEWS  README.md  appdata  auth-dialog  autogen.sh  configure.ac  m4  nm-l2tp-service.conf  nm-l2tp-service.name.in  po  properties  shared  src

$ ./autogen.sh
aclocal: installing 'm4/gettext.m4' from '/usr/share/aclocal/gettext.m4'
aclocal: installing 'm4/iconv.m4' from '/usr/share/aclocal/iconv.m4'
aclocal: installing 'm4/intlmacosx.m4' from '/usr/share/aclocal/intlmacosx.m4'
aclocal: installing 'm4/lib-ld.m4' from '/usr/share/aclocal/lib-ld.m4'
aclocal: installing 'm4/lib-link.m4' from '/usr/share/aclocal/lib-link.m4'
aclocal: installing 'm4/lib-prefix.m4' from '/usr/share/aclocal/lib-prefix.m4'
aclocal: installing 'm4/libtool.m4' from '/usr/share/aclocal/libtool.m4'
aclocal: installing 'm4/ltoptions.m4' from '/usr/share/aclocal/ltoptions.m4'
aclocal: installing 'm4/ltsugar.m4' from '/usr/share/aclocal/ltsugar.m4'
aclocal: installing 'm4/ltversion.m4' from '/usr/share/aclocal/ltversion.m4'
aclocal: installing 'm4/lt~obsolete.m4' from '/usr/share/aclocal/lt~obsolete.m4'
aclocal: installing 'm4/nls.m4' from '/usr/share/aclocal/nls.m4'
aclocal: installing 'm4/pkg.m4' from '/usr/share/aclocal/pkg.m4'
aclocal: installing 'm4/po.m4' from '/usr/share/aclocal/po.m4'
aclocal: installing 'm4/progtest.m4' from '/usr/share/aclocal/progtest.m4'
autoreconf: Entering directory `.'
autoreconf: running: autopoint --force
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
Copying file ABOUT-NLS
Copying file config.rpath
Copying file m4/codeset.m4
Copying file m4/extern-inline.m4
Copying file m4/fcntl-o.m4
Copying file m4/glibc2.m4
Copying file m4/glibc21.m4
Copying file m4/intdiv0.m4
Copying file m4/intl.m4
Copying file m4/intldir.m4
Copying file m4/intmax.m4
Copying file m4/inttypes-pri.m4
Copying file m4/inttypes_h.m4
Copying file m4/lcmessage.m4
Copying file m4/lock.m4
Copying file m4/longlong.m4
Copying file m4/printf-posix.m4
Copying file m4/size_max.m4
Copying file m4/stdint_h.m4
Copying file m4/threadlib.m4
Copying file m4/uintmax_t.m4
Copying file m4/visibility.m4
Copying file m4/wchar_t.m4
Copying file m4/wint_t.m4
Copying file m4/xsize.m4
Copying file po/Makefile.in.in
Copying file po/Makevars.template
Copying file po/Rules-quot
Copying file po/boldquot.sed
Copying file po/en@boldquot.header
Copying file po/en@quot.header
Copying file po/insert-header.sin
Copying file po/quot.sed
Copying file po/remove-potcdate.sin
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:15: installing './compile'
configure.ac:28: installing './config.guess'
configure.ac:28: installing './config.sub'
configure.ac:7: installing './install-sh'
configure.ac:7: installing './missing'
Makefile.am: installing './depcomp'
autoreconf: Leaving directory `.'
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether to enable maintainer-specific portions of Makefiles... yes
checking whether make supports nested variables... (cached) yes
checking whether make supports the include directive... yes (GNU style)
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for gcc-ar... gcc-ar
checking for gcc-ranlib... gcc-ranlib
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... (cached) gcc-ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking for gcc... (cached) gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking whether gcc understands -c and -o together... (cached) yes
checking dependency style of gcc... (cached) gcc3
checking for glib-compile-resources... /usr/bin/glib-compile-resources
checking for file... yes
checking for find... yes
checking for ANSI C header files... (cached) yes
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking paths.h usability... yes
checking paths.h presence... yes
checking for paths.h... yes
checking sys/ioctl.h usability... yes
checking sys/ioctl.h presence... yes
checking for sys/ioctl.h... yes
checking sys/time.h usability... yes
checking sys/time.h presence... yes
checking for sys/time.h... yes
checking syslog.h usability... yes
checking syslog.h presence... yes
checking for syslog.h... yes
checking for unistd.h... (cached) yes
checking pppd/pppd.h usability... yes
checking pppd/pppd.h presence... yes
checking for pppd/pppd.h... yes
checking whether EAP-TLS patch has been applied to pppd... yes
checking for mode_t... yes
checking for pid_t... yes
checking whether time.h and sys/time.h may both be included... yes
checking whether gcc needs -traditional... no
checking for working memcmp... yes
checking for select... yes
checking for socket... yes
checking for uname... yes
checking for library containing dlopen... -ldl
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for OPENSSL... yes
checking for NSS... yes
checking whether NLS is requested... yes
checking for msgfmt... /usr/bin/msgfmt
checking for gmsgfmt... /usr/bin/msgfmt
checking for xgettext... /usr/bin/xgettext
checking for msgmerge... /usr/bin/msgmerge
checking for ld used by gcc... /usr/bin/ld -m elf_x86_64
checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
checking for shared library run path origin... done
checking for CFPreferencesCopyAppValue... no
checking for CFLocaleCopyCurrent... no
checking for GNU gettext in libc... yes
checking whether to use NLS... yes
checking where the gettext function comes from... libc
checking for GLIB... yes
checking for GTK... yes
checking for LIBNMA... yes
checking for LIBSECRET... yes
checking for LIBNM... yes
checking for more warnings... yes
checking whether -Wunknown-warning-option works as expected... not supported
checking whether "-Wextra" works as expected... yes
checking whether "-Wdeclaration-after-statement" works as expected... yes
checking whether "-Wfloat-equal" works as expected... yes
checking whether "-Wformat-nonliteral" works as expected... yes
checking whether "-Wformat-security" works as expected... yes
checking whether "-Wimplicit-fallthrough" works as expected... yes
checking whether "-Wimplicit-function-declaration" works as expected... yes
checking whether "-Winit-self" works as expected... yes
checking whether "-Wmissing-declarations" works as expected... yes
checking whether "-Wmissing-include-dirs" works as expected... yes
checking whether "-Wmissing-prototypes" works as expected... yes
checking whether "-Wpointer-arith" works as expected... yes
checking whether "-Wshadow" works as expected... yes
checking whether "-Wstrict-prototypes" works as expected... yes
checking whether "-Wundef" works as expected... yes
checking whether "-Wno-duplicate-decl-specifier" works as expected... yes
checking whether "-Wno-format-truncation" works as expected... yes
checking whether "-Wno-format-y2k" works as expected... yes
checking whether "-Wno-missing-field-initializers" works as expected... yes
checking whether "-Wno-pragmas" works as expected... yes
checking whether "-Wno-sign-compare" works as expected... yes
checking whether "-Wno-unused-but-set-variable" works as expected... yes
checking whether "-Wno-unused-parameter" works as expected... yes
checking whether -Wunknown-attributes works as expected... not supported
checking whether -Wtypedef-redefinition works as expected... not supported
checking whether -Warray-bounds works as expected... yes
checking whether -Wparentheses-equality works as expected... not supported
checking whether -Wunused-value works as expected... yes
checking if gcc supports flag -fdata-sections -ffunction-sections -Wl,--gc-sections in envvar CFLAGS... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating po/Makefile.in
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
config.status: executing po-directories commands
config.status: creating po/POTFILES
config.status: creating po/Makefile

Build configuration: 
  --with-dist-version=
  --with-gnome=yes
  --with-pppd-plugin-dir=${exec_prefix}/lib/pppd/2.4.9
  --enable-absolute-paths=no
  --enable-more-warnings=error
  --enable-lto=no
  --enable-ld-gc=yes

$ ./configure \
>   --disable-static --prefix=/usr \
>   --sysconfdir=/etc --libdir=/usr/lib/x86_64-linux-gnu \
>   --libexecdir=/usr/lib/NetworkManager \
>   --localstatedir=/var \
>   --with-pppd-plugin-dir=/usr/lib/pppd/2.4.7
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether to enable maintainer-specific portions of Makefiles... no
checking whether make supports nested variables... (cached) yes
checking whether make supports the include directive... yes (GNU style)
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for gcc-ar... gcc-ar
checking for gcc-ranlib... gcc-ranlib
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... (cached) gcc-ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking for gcc... (cached) gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking whether gcc understands -c and -o together... (cached) yes
checking dependency style of gcc... (cached) gcc3
checking for glib-compile-resources... /usr/bin/glib-compile-resources
checking for file... yes
checking for find... yes
checking for ANSI C header files... (cached) yes
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking paths.h usability... yes
checking paths.h presence... yes
checking for paths.h... yes
checking sys/ioctl.h usability... yes
checking sys/ioctl.h presence... yes
checking for sys/ioctl.h... yes
checking sys/time.h usability... yes
checking sys/time.h presence... yes
checking for sys/time.h... yes
checking syslog.h usability... yes
checking syslog.h presence... yes
checking for syslog.h... yes
checking for unistd.h... (cached) yes
checking pppd/pppd.h usability... yes
checking pppd/pppd.h presence... yes
checking for pppd/pppd.h... yes
checking whether EAP-TLS patch has been applied to pppd... yes
checking for mode_t... yes
checking for pid_t... yes
checking whether time.h and sys/time.h may both be included... yes
checking whether gcc needs -traditional... no
checking for working memcmp... yes
checking for select... yes
checking for socket... yes
checking for uname... yes
checking for library containing dlopen... -ldl
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for OPENSSL... yes
checking for NSS... yes
checking whether NLS is requested... yes
checking for msgfmt... /usr/bin/msgfmt
checking for gmsgfmt... /usr/bin/msgfmt
checking for xgettext... /usr/bin/xgettext
checking for msgmerge... /usr/bin/msgmerge
checking for ld used by gcc... /usr/bin/ld -m elf_x86_64
checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
checking for shared library run path origin... done
checking for CFPreferencesCopyAppValue... no
checking for CFLocaleCopyCurrent... no
checking for GNU gettext in libc... yes
checking whether to use NLS... yes
checking where the gettext function comes from... libc
checking for GLIB... yes
checking for GTK... yes
checking for LIBNMA... yes
checking for LIBSECRET... yes
checking for LIBNM... yes
checking for more warnings... yes
checking whether -Wunknown-warning-option works as expected... not supported
checking whether "-Wextra" works as expected... yes
checking whether "-Wdeclaration-after-statement" works as expected... yes
checking whether "-Wfloat-equal" works as expected... yes
checking whether "-Wformat-nonliteral" works as expected... yes
checking whether "-Wformat-security" works as expected... yes
checking whether "-Wimplicit-fallthrough" works as expected... yes
checking whether "-Wimplicit-function-declaration" works as expected... yes
checking whether "-Winit-self" works as expected... yes
checking whether "-Wmissing-declarations" works as expected... yes
checking whether "-Wmissing-include-dirs" works as expected... yes
checking whether "-Wmissing-prototypes" works as expected... yes
checking whether "-Wpointer-arith" works as expected... yes
checking whether "-Wshadow" works as expected... yes
checking whether "-Wstrict-prototypes" works as expected... yes
checking whether "-Wundef" works as expected... yes
checking whether "-Wno-duplicate-decl-specifier" works as expected... yes
checking whether "-Wno-format-truncation" works as expected... yes
checking whether "-Wno-format-y2k" works as expected... yes
checking whether "-Wno-missing-field-initializers" works as expected... yes
checking whether "-Wno-pragmas" works as expected... yes
checking whether "-Wno-sign-compare" works as expected... yes
checking whether "-Wno-unused-but-set-variable" works as expected... yes
checking whether "-Wno-unused-parameter" works as expected... yes
checking whether -Wunknown-attributes works as expected... not supported
checking whether -Wtypedef-redefinition works as expected... not supported
checking whether -Warray-bounds works as expected... yes
checking whether -Wparentheses-equality works as expected... not supported
checking whether -Wunused-value works as expected... yes
checking if gcc supports flag -fdata-sections -ffunction-sections -Wl,--gc-sections in envvar CFLAGS... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating po/Makefile.in
config.status: creating config.h
config.status: config.h is unchanged
config.status: executing depfiles commands
config.status: executing libtool commands
config.status: executing po-directories commands
config.status: creating po/POTFILES
config.status: creating po/Makefile

Build configuration: 
  --with-dist-version=
  --with-gnome=yes
  --with-pppd-plugin-dir=/usr/lib/pppd/2.4.7
  --enable-absolute-paths=no
  --enable-more-warnings=
  --enable-lto=no
  --enable-ld-gc=yes

$ make
  GEN      src/nm-l2tp-pppd-service-dbus.h
make  all-recursive
make[1]: ディレクトリ '/home/sylph01/nml2tp_' に入ります
Making all in .
make[2]: ディレクトリ '/home/sylph01/nml2tp_' に入ります
  CC       shared/nm-utils/src_nm_l2tp_service-nm-shared-utils.o
  CC       shared/src_nm_l2tp_service-nm-l2tp-crypto-openssl.o
  CC       shared/src_nm_l2tp_service-nm-l2tp-crypto-nss.o
  CC       shared/src_nm_l2tp_service-utils.o
  CC       src/nm_l2tp_service-nm-l2tp-service.o
  CC       src/libnm_l2tp_pppd_service_dbus_la-nm-l2tp-pppd-service-dbus.lo
  CCLD     src/libnm-l2tp-pppd-service-dbus.la
  CCLD     src/nm-l2tp-service
  CC       shared/nm-utils/auth_dialog_nm_l2tp_auth_dialog-nm-shared-utils.o
  CC       shared/auth_dialog_nm_l2tp_auth_dialog-nm-l2tp-crypto-openssl.o
  CC       shared/nm-utils/auth_dialog_nm_l2tp_auth_dialog-nm-secret-utils.o
  GEN      properties/resources.c
  CC       properties/auth_dialog_nm_l2tp_auth_dialog-resources.o
  CC       auth-dialog/nm_l2tp_auth_dialog-main.o
  CCLD     auth-dialog/nm-l2tp-auth-dialog
  CC       shared/nm-utils/properties_libnm_vpn_plugin_l2tp_la-nm-vpn-plugin-utils.lo
  CC       shared/properties_libnm_vpn_plugin_l2tp_la-nm-l2tp-crypto-openssl.lo
  CC       properties/libnm_vpn_plugin_l2tp_la-nm-l2tp-editor-plugin.lo
  CC       properties/libnm_vpn_plugin_l2tp_la-import-export.lo
properties/import-export.c: In function ‘ip4_import_error’:
properties/import-export.c:133:17: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
  133 |                 val);
      |                 ^~~
  CCLD     properties/libnm-vpn-plugin-l2tp.la
  CC       shared/nm-utils/properties_libnm_vpn_plugin_l2tp_editor_la-nm-shared-utils.lo
  CC       shared/properties_libnm_vpn_plugin_l2tp_editor_la-nm-l2tp-crypto-openssl.lo
  CC       shared/properties_libnm_vpn_plugin_l2tp_editor_la-utils.lo
  CC       properties/libnm_vpn_plugin_l2tp_editor_la-resources.lo
  CC       properties/libnm_vpn_plugin_l2tp_editor_la-ppp-dialog.lo
  CC       properties/libnm_vpn_plugin_l2tp_editor_la-ipsec-dialog.lo
  CC       properties/libnm_vpn_plugin_l2tp_editor_la-nm-l2tp-editor.lo
  CC       properties/libnm_vpn_plugin_l2tp_editor_la-auth-helpers.lo
  CCLD     properties/libnm-vpn-plugin-l2tp-editor.la
  CC       shared/nm-utils/src_nm_l2tp_pppd_plugin_la-nm-shared-utils.lo
  CC       src/nm_l2tp_pppd_plugin_la-nm-l2tp-pppd-plugin.lo
  CCLD     src/nm-l2tp-pppd-plugin.la
  GEN      appdata/network-manager-l2tp.metainfo.xml
./po/ru.po:220:25: 不正な制御シーケンス
/usr/bin/msgfmt: 1 個の致命的エラーが見つかりました
make[2]: *** [Makefile:2013: appdata/network-manager-l2tp.metainfo.xml] エラー 1
make[2]: ディレクトリ '/home/sylph01/nml2tp_' から出ます
make[1]: *** [Makefile:1494: all-recursive] エラー 1
make[1]: ディレクトリ '/home/sylph01/nml2tp_' から出ます
make: *** [Makefile:787: all] エラー 2
```