### PR TITLE
Fix detecting libreswan on newer vesions

### DIFF
--- a/shared/utils.c
+++ b/shared/utils.c
@@ -27,7 +27,7 @@ check_ipsec_daemon(const char *path)
         if (strstr(output, " strongSwan "))
             return NM_L2TP_IPSEC_DAEMON_STRONGSWAN;
 
-        if (strstr(output, " Libreswan "))
+        if (strstr(output, " Libreswan ") || strstr(output, "Libreswan ") == output)
             return NM_L2TP_IPSEC_DAEMON_LIBRESWAN;
 
         if (strstr(output, " Openswan "))


### PR DESCRIPTION
Starting from libreswan 4.9, it has started to print a simplified version string; e.g. "Libreswan 4.9", so we need to modify how we detect libreswan accordingly. This change adds detecting newer versions in addition to the older ones.

Note: I've not tested the change yet :( I'll try to test it soon.