### PR TITLE
properties: fix possible out-of-bounds access in export_ip4

### DIFF
--- a/properties/import-export.c
+++ b/properties/import-export.c
@@ -552,7 +552,7 @@ export_ip4(NMSettingIPConfig *s_ip4, GKeyFile *keyfile, GError **error)
                                    NM_SETTING_IP_CONFIG_ROUTES,
                                    (const gchar *const *) routes,
                                    num_routes);
-        for (i = 0; i < num_dns; i++)
+        for (i = 0; i < num_routes; i++)
             g_free(routes[i]);
     }
 


### PR DESCRIPTION
When exporting static routes configured for VPN connection, `export_ip4` function uses `num_dns` instead of `num_routes` variable, which may cause out-of-bounds access to `routes` array.

This issue surfaces itself as `double free or corruption` error in my case.