### PR TITLE
Add ipsec-left vpn-data option

### DIFF
--- a/properties/import-export.c
+++ b/properties/import-export.c
@@ -104,6 +104,7 @@ static VpnImportExportProperty vpn_properties[] = {
     {NM_L2TP_KEY_IPSEC_IPCOMP, G_TYPE_BOOLEAN, FALSE},
     {NM_L2TP_KEY_IPSEC_IKEV2, G_TYPE_BOOLEAN, FALSE},
     {NM_L2TP_KEY_IPSEC_PFS, G_TYPE_BOOLEAN, FALSE},
+    {NM_L2TP_KEY_IPSEC_LEFT, G_TYPE_STRING, FALSE},
     /* { NM_L2TP_KEY_PASSWORD"-flags",         G_TYPE_UINT, FALSE },*/
     /* { NM_L2TP_KEY_USER_CERTPASS"-flags",    G_TYPE_UINT, FALSE },*/
     /* { NM_L2TP_KEY_IPSEC_PSK"-flags",        G_TYPE_UINT, FALSE },*/

--- a/properties/ipsec-dialog.c
+++ b/properties/ipsec-dialog.c
@@ -41,6 +41,7 @@ static const char *ipsec_keys[] = {NM_L2TP_KEY_IPSEC_ENABLE,
                                    NM_L2TP_KEY_IPSEC_IPCOMP,
                                    NM_L2TP_KEY_IPSEC_IKEV2,
                                    NM_L2TP_KEY_IPSEC_PFS,
+                                   NM_L2TP_KEY_IPSEC_LEFT,
                                    NM_L2TP_KEY_IPSEC_PSK "-flags",
                                    NM_L2TP_KEY_MACHINE_CERTPASS "-flags",
                                    NULL};

--- a/shared/nm-service-defines.h
+++ b/shared/nm-service-defines.h
@@ -66,6 +66,7 @@
 #define NM_L2TP_KEY_IPSEC_IPCOMP      "ipsec-ipcomp"
 #define NM_L2TP_KEY_IPSEC_IKEV2       "ipsec-ikev2"
 #define NM_L2TP_KEY_IPSEC_PFS         "ipsec-pfs"
+#define NM_L2TP_KEY_IPSEC_LEFT        "ipsec-left"
 
 /* Internal auth-dialog -> service token indicating that no secrets are required
  * for the connection if X.509 private keys are used with no password protection.

--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -202,6 +202,7 @@ static const ValidProperty valid_properties[] = {
     {NM_L2TP_KEY_IPSEC_IPCOMP, G_TYPE_BOOLEAN, FALSE},
     {NM_L2TP_KEY_IPSEC_IKEV2, G_TYPE_BOOLEAN, FALSE},
     {NM_L2TP_KEY_IPSEC_PFS, G_TYPE_BOOLEAN, FALSE},
+    {NM_L2TP_KEY_IPSEC_LEFT, G_TYPE_STRING, FALSE},
     {NM_L2TP_KEY_PASSWORD "-flags", G_TYPE_UINT, FALSE},
     {NM_L2TP_KEY_USER_CERTPASS "-flags", G_TYPE_UINT, FALSE},
     {NM_L2TP_KEY_IPSEC_PSK "-flags", G_TYPE_UINT, FALSE},
@@ -917,7 +918,8 @@ nm_l2tp_config_write(NML2tpPlugin *plugin, NMSettingVpn *s_vpn, GError **error)
             write_config_option(fd, "  authby=secret\n");
         }
 
-        write_config_option(fd, "  left=%%defaultroute\n");
+        value = nm_setting_vpn_get_data_item(s_vpn, NM_L2TP_KEY_IPSEC_LEFT);
+        write_config_option(fd, "  left=%s\n", value ? value : "%defaultroute");
         if (!use_ephemeral_port) {
             write_config_option(fd, "  leftprotoport=udp/l2tp\n");
         }


### PR DESCRIPTION
By default a value of %defaultroute is used for the "left" parameter of the IPSec daemon configuration. However that is not suitable on a machine that needs to establish the IPSec connection via an interface that does not correspond to the default route.

Add a "ipsec-left" option for vpn-data that allows a custom value to be passed as the ipsec.conf "left" option for these more advanced setup scenarios.