### PR TITLE
service: determine correct local IP address for IPSec

### DIFF
--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -83,6 +83,10 @@ typedef struct {
     /* IP of L2TP gateway in numeric and string format */
     guint32 naddr;
     char *  saddr;
+
+    /* Local IP route to the L2TP gateway */
+    char *  slocaladdr;
+
 } NML2tpPluginPrivate;
 
 #define NM_L2TP_PLUGIN_GET_PRIVATE(o) \
@@ -917,7 +921,7 @@ nm_l2tp_config_write(NML2tpPlugin *plugin, NMSettingVpn *s_vpn, GError **error)
             write_config_option(fd, "  authby=secret\n");
         }
 
-        write_config_option(fd, "  left=%%defaultroute\n");
+        write_config_option(fd, "  left=%s\n", priv->slocaladdr);
         if (!use_ephemeral_port) {
             write_config_option(fd, "  leftprotoport=udp/l2tp\n");
         }
@@ -1885,6 +1889,42 @@ lookup_gateway(NML2tpPlugin *self, const char *src, GError **error)
 }
 
 static gboolean
+get_localaddr (NML2tpPlugin *self,
+               GError **error)
+{
+    NML2tpPluginPrivate *priv = NM_L2TP_PLUGIN_GET_PRIVATE (self);
+    char abuf[INET_ADDRSTRLEN+1] = {};
+    struct sockaddr_in addr = {};
+    socklen_t alen = sizeof(addr);
+    int fd;
+
+    fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        return nm_l2tp_ipsec_error(error, _("couldn't determine local IP to contact L2TP VPN gateway"));
+    }
+
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(1701);
+    addr.sin_addr.s_addr = priv->naddr;
+
+    if (0 != connect (fd, &addr, sizeof(addr))) {
+        close (fd);
+        return nm_l2tp_ipsec_error(error, _("unable to connect to L2TP VPN gateway"));
+    }
+
+    memset( &addr, 0, sizeof(addr));
+    if (0 != getsockname( fd, &addr, &alen)) {
+        close (fd);
+        return nm_l2tp_ipsec_error(error, _("failed to get local IP"));
+    }
+
+    priv->slocaladdr = g_strdup (inet_ntop (AF_INET, &addr.sin_addr.s_addr, abuf, alen-1));
+    close(fd);
+
+    return TRUE;
+}
+
+static gboolean
 real_connect(NMVpnServicePlugin *plugin, NMConnection *connection, GError **error)
 {
     NML2tpPluginPrivate *priv = NM_L2TP_PLUGIN_GET_PRIVATE(plugin);
@@ -1944,6 +1984,9 @@ real_connect(NMVpnServicePlugin *plugin, NMConnection *connection, GError **erro
      * using for the connection, we wouldn't need to do this...
      */
     if (!lookup_gateway(NM_L2TP_PLUGIN(plugin), gwaddr, error))
+        return FALSE;
+
+    if (!get_localaddr(NM_L2TP_PLUGIN (plugin), error))
         return FALSE;
 
     if (!nm_l2tp_properties_validate(s_vpn, error))
@@ -2091,6 +2134,10 @@ real_disconnect(NMVpnServicePlugin *plugin, GError **err)
     if (priv->saddr) {
         g_free(priv->saddr);
         priv->saddr = NULL;
+    }
+    if (priv->slocaladdr) {
+        g_free (priv->slocaladdr);
+        priv->slocaladdr = NULL;
     }
 
     if (!gl.debug) {


### PR DESCRIPTION
The ipsec %defaultroute keyword is used to have Strongswan/Libreswan use the local address of the default route network interface at the point of startup or configuration reload.  It's probably a fair bet that this would be the interface used to connect to the VPN gateway, but that's not guaranteed. To support the latter, determine the IP address directly by connecting to the gateway and using the getsockname(2) system call to derive the local socket address.

Adapted from:
https://github.com/katalix/NetworkManager-l2tp/commit/2d1720e17ddf9b7a7d02399e6a1eacb747080cd8
Credits to https://github.com/katalix and https://github.com/tomparkin for the original work.